### PR TITLE
3.34.x hotfix branch with cherry picks (#1507)

### DIFF
--- a/azkaban-common/build.gradle
+++ b/azkaban-common/build.gradle
@@ -42,10 +42,10 @@ dependencies {
     compile deps.fileupload
     compile deps.guava
     compile deps.gson
-    compile deps.hadoopAnnotations
-    compile deps.hadoopAuth
-    compile deps.hadoopCommon
-    compile deps.hadoopHdfs
+    compileOnly deps.hadoopAnnotations
+    compileOnly deps.hadoopAuth
+    compileOnly deps.hadoopCommon
+    compileOnly deps.hadoopHdfs
     compile deps.httpclient
     compile deps.io
     compile deps.jacksonCoreAsl
@@ -66,6 +66,10 @@ dependencies {
 
     testRuntime deps.h2
 
+    testCompile deps.hadoopAnnotations
+    testCompile deps.hadoopAuth
+    testCompile deps.hadoopCommon
+    testCompile deps.hadoopHdfs
     testCompile project(':test')
     testCompile project(path: ':azkaban-db', configuration: 'testOutput')
 }

--- a/azkaban-exec-server/build.gradle
+++ b/azkaban-exec-server/build.gradle
@@ -10,7 +10,11 @@ dependencies {
     testCompile(project(path: ':azkaban-common', configuration: 'testCompile'))
     testCompile(project(':azkaban-common').sourceSets.test.output)
 
-    testRuntime deps.h2
+    testCompile deps.h2
+    testCompile deps.hadoopAnnotations
+    testCompile deps.hadoopAuth
+    testCompile deps.hadoopCommon
+    testCompile deps.hadoopHdfs
 }
 
 distributions {

--- a/azkaban-solo-server/build.gradle
+++ b/azkaban-solo-server/build.gradle
@@ -7,6 +7,10 @@ dependencies {
     compile(project(':azkaban-exec-server'))
 
     runtime deps.h2
+    compile deps.hadoopAnnotations
+    compile deps.hadoopAuth
+    compile deps.hadoopCommon
+    compile deps.hadoopHdfs
 }
 
 installDist.dependsOn ':azkaban-web-server:installDist'


### PR DESCRIPTION
* build: change hadoop gradle dependencies to compileOnly (#1499)

* build: change hadoop gradle dependencies to compileOnly instead of incuding them as runtime dependencies

* Fix tests broken due to moving to compileOnly for hadoop dependencies.
Fix was to use testCompile to include hadoop dependencies.
Also fixed transitive dependencies from gobblinKafka dependency

* Fix azkaban-solo-server by including hadoop dependencies in build.gradle (#1503)

* Fix cherry-pick by removing unnecessary gobblin-kafka dependency